### PR TITLE
Rename git init script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Hybrid Dancers
+
+This repository contains the public site for Hybrid Dancers.
+
+## Git Setup
+
+To set up the repository locally, run the provided setup script:
+
+```bash
+./git-init.sh
+```
+
+The script initializes Git and pushes the initial commit to GitHub. Make sure it is executable before running.

--- a/git-init.sh
+++ b/git-init.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 git init
 git remote add origin https://github.com/Csp-Ai/hybriddancers-site.git
 git add .


### PR DESCRIPTION
## Summary
- rename `git init.py` to `git-init.sh`
- add executable permissions and shebang
- document setup script in new README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850507811788323a907b7a3c9805365