### PR TITLE
Add login and signup pages with Firebase auth

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,90 @@
+// Firebase Authentication helpers for Hybrid Dancers site
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_AUTH_DOMAIN",
+    projectId: "YOUR_PROJECT_ID"
+};
+if (!firebase.apps.length) {
+    firebase.initializeApp(firebaseConfig);
+}
+const auth = firebase.auth();
+
+function updateAccountLink(user) {
+    const link = document.getElementById('accountLink');
+    if (!link) return;
+    if (user) {
+        link.innerHTML = '<i class="fas fa-user-circle"></i> My Account';
+        link.href = 'dashboard.html';
+    } else {
+        link.textContent = 'Log In';
+        link.href = 'login.html';
+    }
+}
+
+auth.onAuthStateChanged(user => {
+    updateAccountLink(user);
+    const userName = document.getElementById('userName');
+    const membership = document.getElementById('membershipStatus');
+    if (user && userName) {
+        userName.textContent = user.displayName || 'Dancer';
+        if (membership) membership.textContent = 'Membership Status: Active';
+    }
+    if (!user && document.body.classList.contains('dashboard-page')) {
+        window.location.href = 'login.html';
+    }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const loginForm = document.getElementById('login-form');
+    if (loginForm) {
+        loginForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const email = document.getElementById('loginEmail').value;
+            const password = document.getElementById('loginPassword').value;
+            auth.signInWithEmailAndPassword(email, password)
+                .then(() => window.location.href = 'dashboard.html')
+                .catch(err => alert(err.message));
+        });
+    }
+
+    const signupForm = document.getElementById('signup-form');
+    if (signupForm) {
+        signupForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const name = document.getElementById('signupName').value;
+            const email = document.getElementById('signupEmail').value;
+            const password = document.getElementById('signupPassword').value;
+            auth.createUserWithEmailAndPassword(email, password)
+                .then(res => res.user.updateProfile({ displayName: name }))
+                .then(() => window.location.href = 'dashboard.html')
+                .catch(err => alert(err.message));
+        });
+    }
+
+    const logoutBtn = document.getElementById('logoutBtn');
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', () => {
+            auth.signOut().then(() => window.location.href = 'index.html');
+        });
+    }
+
+    const bookClassBtn = document.getElementById('bookClassBtn');
+    if (bookClassBtn) {
+        bookClassBtn.addEventListener('click', () => {
+            window.location.href = 'booking.html';
+        });
+    }
+
+    document.querySelectorAll('.toggle-password').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const target = document.getElementById(btn.dataset.target);
+            if (target.type === 'password') {
+                target.type = 'text';
+                btn.innerHTML = '<i class="fas fa-eye-slash"></i>';
+            } else {
+                target.type = 'password';
+                btn.innerHTML = '<i class="fas fa-eye"></i>';
+            }
+        });
+    });
+});

--- a/booking.html
+++ b/booking.html
@@ -81,6 +81,7 @@
                 <li><a href="index.html#pricing">Pricing</a></li>
                 <li><a href="index.html#community">Community</a></li>
                 <li><a href="events.html">Events</a></li>
+                <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
             </ul>
         </div>
     </nav>
@@ -111,5 +112,6 @@
     <script src="booking.js"></script>
     <script src="https://unpkg.com/scrollreveal"></script>
     <script src="scripts.js"></script>
+    <script src="auth.js"></script>
   </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Account - Hybrid Dancers</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="dashboard-page">
+  <nav class="nav">
+    <div class="nav-container">
+      <div class="logo">Hybrid Dancers</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="instructor.html">Instructor</a></li>
+        <li><a href="index.html#pricing">Pricing</a></li>
+        <li><a href="index.html#community">Community</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <section class="dashboard">
+    <div class="dashboard-inner">
+      <h2>Welcome, <span id="userName">Dancer</span>!</h2>
+      <p id="membershipStatus">Membership Status: Free Trial</p>
+      <h3>Upcoming Classes</h3>
+      <ul id="upcomingClasses" class="class-list">
+        <li>No bookings yet.</li>
+      </ul>
+      <button class="auth-btn" id="bookClassBtn">Book Another Class</button>
+      <button class="logout-btn" id="logoutBtn">Log Out</button>
+    </div>
+  </section>
+
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/events.html
+++ b/events.html
@@ -51,6 +51,7 @@
         <li><a href="index.html#pricing">Pricing</a></li>
         <li><a href="index.html#community">Community</a></li>
         <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
       </ul>
     </div>
   </nav>
@@ -79,6 +80,7 @@
   </section>
   <script src="https://unpkg.com/scrollreveal"></script>
   <script src="scripts.js"></script>
+  <script src="auth.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                 <li><a href="#pricing">Pricing</a></li>
                 <li><a href="#community">Community</a></li>
                 <li><a href="events.html">Events</a></li>
+                <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
             </ul>
         </div>
     </nav>
@@ -181,5 +182,6 @@
     </script>
     <script src="https://unpkg.com/scrollreveal"></script>
     <script src="scripts.js"></script>
+    <script src="auth.js"></script>
   </body>
 </html>

--- a/instructor.html
+++ b/instructor.html
@@ -113,6 +113,7 @@
                 <li><a href="index.html#pricing">Pricing</a></li>
                 <li><a href="index.html#community">Community</a></li>
                 <li><a href="events.html">Events</a></li>
+                <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
             </ul>
         </div>
     </nav>
@@ -132,5 +133,6 @@
     </section>
     <script src="https://unpkg.com/scrollreveal"></script>
     <script src="scripts.js"></script>
+    <script src="auth.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Log In - Hybrid Dancers</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-container">
+      <div class="logo">Hybrid Dancers</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="instructor.html">Instructor</a></li>
+        <li><a href="index.html#pricing">Pricing</a></li>
+        <li><a href="index.html#community">Community</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <section class="auth-section">
+    <form id="login-form" class="auth-form">
+      <h2>Log In</h2>
+      <label for="loginEmail">Email</label>
+      <input id="loginEmail" type="email" required>
+      <label for="loginPassword">Password</label>
+      <div class="password-wrapper">
+        <input id="loginPassword" type="password" required>
+        <button type="button" class="toggle-password" data-target="loginPassword"><i class="fas fa-eye"></i></button>
+      </div>
+      <button type="submit" class="auth-btn">Log In</button>
+      <p class="form-switch">Don't have an account? <a href="signup.html">Sign Up</a></p>
+    </form>
+  </section>
+
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -267,6 +267,7 @@
         <li><a href="index.html#pricing">Pricing</a></li>
         <li><a href="index.html#community">Community</a></li>
         <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
       </ul>
     </div>
   </nav>
@@ -358,5 +359,6 @@
   </script>
   <script src="https://unpkg.com/scrollreveal"></script>
   <script src="scripts.js"></script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign Up - Hybrid Dancers</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-container">
+      <div class="logo">Hybrid Dancers</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="instructor.html">Instructor</a></li>
+        <li><a href="index.html#pricing">Pricing</a></li>
+        <li><a href="index.html#community">Community</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <section class="auth-section">
+    <form id="signup-form" class="auth-form">
+      <h2>Create Account</h2>
+      <label for="signupName">Name</label>
+      <input id="signupName" type="text" required>
+      <label for="signupEmail">Email</label>
+      <input id="signupEmail" type="email" required>
+      <label for="signupPassword">Password</label>
+      <div class="password-wrapper">
+        <input id="signupPassword" type="password" required>
+        <button type="button" class="toggle-password" data-target="signupPassword"><i class="fas fa-eye"></i></button>
+      </div>
+      <button type="submit" class="auth-btn">Sign Up</button>
+      <p class="form-switch">Already have an account? <a href="login.html">Log In</a></p>
+    </form>
+  </section>
+
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -792,3 +792,112 @@
             color: #F5F5DC;
             font-style: italic;
         }
+
+/* ----- Auth Forms & Dashboard ----- */
+.auth-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 6rem 1rem;
+}
+
+.auth-form {
+    background: white;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+    max-width: 400px;
+    width: 100%;
+}
+
+.auth-form h2 {
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
+.auth-form label {
+    display: block;
+    margin-top: 1rem;
+    font-weight: bold;
+}
+
+.auth-form input {
+    width: 100%;
+    padding: 0.75rem;
+    margin-top: 0.25rem;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+.password-wrapper {
+    position: relative;
+}
+
+.toggle-password {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #666;
+}
+
+.auth-btn {
+    display: block;
+    margin-top: 1.5rem;
+    width: 100%;
+    padding: 0.75rem 2rem;
+    background: #feca57;
+    color: #1a1a1a;
+    border: none;
+    border-radius: 25px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.auth-btn:hover {
+    background: #ff6b6b;
+    color: white;
+}
+
+.form-switch {
+    margin-top: 1rem;
+    text-align: center;
+}
+
+.dashboard {
+    padding: 6rem 1rem;
+}
+
+.dashboard-inner {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+.class-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0;
+}
+
+.logout-btn {
+    margin-top: 1rem;
+    background: #ddd;
+    border: none;
+    border-radius: 25px;
+    padding: 0.5rem 1.5rem;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.logout-btn:hover {
+    background: #ccc;
+}


### PR DESCRIPTION
## Summary
- implement login, signup, and dashboard pages
- add Firebase-based `auth.js` script to manage sessions
- update navigation on all pages with account link
- style auth forms and dashboard

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c70031108323a45f8db83135b3f7