### PR TITLE
Add contributing guidelines and sample tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Example environment configuration for Hybrid Dancers
+STRIPE_SECRET_KEY=sk_test_your_secret_key
+STRIPE_PUBLIC_KEY=pk_test_your_public_key
+
+# Firebase configuration
+FIREBASE_API_KEY=your_firebase_api_key
+FIREBASE_AUTH_DOMAIN=hybriddancers.firebaseapp.com
+FIREBASE_PROJECT_ID=hybriddancers
+FIREBASE_STORAGE_BUCKET=hybriddancers.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+FIREBASE_APP_ID=your_app_id
+FIREBASE_MEASUREMENT_ID=G-XXXXXXX
+
+# Optional server port
+PORT=4242

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Hybrid Dancers
+
+Thank you for helping improve the Hybrid Dancers website! This project mixes a small Node.js server with static HTML, CSS and JavaScript. Automated tests live in the `tests/` folder and run with **pytest**.
+
+## Project Setup
+
+1. Install Node dependencies:
+   ```bash
+   npm install
+   ```
+2. Install Python test dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `.env.example` to `.env` and update the values for your local environment.
+
+## Development Workflow
+
+1. Create a feature branch from `main`.
+2. Make your changes and add tests when appropriate.
+3. Run the test suite:
+   ```bash
+   pytest
+   ```
+4. Commit using a clear message in the present tense.
+5. Open a pull request targeting `main`.
+
+## Code Standards
+
+- JavaScript and HTML use **2 spaces** for indentation.
+- Keep functions small and well commented.
+- Use environment variables for secrets; never hard‑code API keys.
+- Ensure `pytest` passes before submitting.
+
+We appreciate all issues and pull requests. Happy coding!

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Tests
+
+This folder contains automated tests for the Hybrid Dancers project.
+
+- `test_html.py` checks the basic HTML structure of `index.html`.
+- `test_booking.py` sends a sample request to the booking endpoint. It will skip if the Node server is not running locally.
+- `test_auth.py` is a placeholder for future authentication tests.
+
+Run all tests with:
+
+```bash
+pytest
+```

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,4 @@
+# Placeholder for future authentication tests
+
+def test_auth_placeholder():
+    pass

--- a/tests/test_booking.py
+++ b/tests/test_booking.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+
+BASE_URL = os.environ.get("TEST_BASE_URL", "http://localhost:4242")
+
+def test_create_checkout_session():
+    try:
+        import requests
+    except ImportError as exc:
+        pytest.skip(f"requests not installed: {exc}")
+
+    data = {"name": "Test", "email": "test@example.com", "classType": "Hip Hop"}
+    try:
+        resp = requests.post(f"{BASE_URL}/create-checkout-session", json=data, timeout=5)
+    except Exception as exc:
+        pytest.skip(f"Server not running: {exc}")
+    assert resp.status_code in (200, 400, 500)


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with setup and workflow instructions
- provide `.env.example` showing required configuration
- add booking and auth tests plus a README for the tests folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685396f37f488323b976d0aa9b3b7890