### PR TITLE
Add student dashboard with class booking, schedule, wellness, and AI insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Remove any existing records that point to GitHub Pages or other providers (for e
 
 Open the file in your browser (or deploy it alongside the site) and sign in to access these tools.
 
+## 🎓 Student Dashboard
+
+`student-dashboard.html` lets each student manage their classes and wellbeing. After logging in you can:
+
+- Browse upcoming classes and book a spot
+- See your personal schedule and cancel bookings
+- View studio events and RSVP
+- Track your mood in the Wellness Journal and view trends
+- Read simple **AI Insights** about your attendance and mood
+
+All data is tied to your logged in Firebase account. Mock data is used for class lists and events, but it can be replaced with real backend calls.
+
 
 
 

--- a/student-dashboard.html
+++ b/student-dashboard.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Student Dashboard - Hybrid Dancers</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; margin:0; }
+    .dash-section { padding:2rem; max-width:800px; margin:0 auto; }
+    .dash-section h2 { margin-bottom:1rem; }
+    .dash-section ul { list-style:none; padding:0; }
+    .dash-section li { margin-bottom:0.5rem; }
+    button { margin-left:0.5rem; }
+    #wellnessJournal textarea { width:100%; height:80px; margin-top:0.5rem; }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-container">
+      <div class="logo">Hybrid Dancers</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="instructor.html">Instructor</a></li>
+        <li><a href="index.html#pricing">Pricing</a></li>
+        <li><a href="index.html#community">Community</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li class="account-link"><a id="accountLink" href="login.html">Log In</a></li>
+        <li id="welcomeMsg" class="welcome-msg" style="display:none;"></li>
+        <li class="account-link" id="logoutNavItem" style="display:none;"><a id="logoutNav" href="#">Log Out</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <section class="dash-section" id="profile">
+    <h2>Profile</h2>
+    <p>Email: <span id="userEmail"></span></p>
+    <p>Membership Status: <span id="membershipStatus"></span></p>
+  </section>
+
+  <section class="dash-section" id="classBooking">
+    <h2>Available Classes</h2>
+    <label for="classFilter">Filter:</label>
+    <select id="classFilter">
+      <option>All</option>
+      <option>Hip Hop</option>
+      <option>Shuffle</option>
+      <option>Contemporary</option>
+    </select>
+    <ul id="classList"></ul>
+  </section>
+
+  <section class="dash-section" id="mySchedule">
+    <h2>My Schedule</h2>
+    <ul id="scheduleList"></ul>
+  </section>
+
+  <section class="dash-section" id="upcomingEvents">
+    <h2>Upcoming Events</h2>
+    <ul id="eventsList"></ul>
+  </section>
+
+  <section class="dash-section" id="wellnessJournal">
+    <h2>Wellness Journal</h2>
+    <label for="moodSelect">Mood (1-5):</label>
+    <select id="moodSelect">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+    </select>
+    <textarea id="journalText" placeholder="Today I'm feeling..."></textarea>
+    <button id="saveJournal">Save Entry</button>
+    <canvas id="moodChart" height="100"></canvas>
+  </section>
+
+  <section class="dash-section" id="aiInsights">
+    <h2>AI Insights</h2>
+    <div id="insights"></div>
+  </section>
+
+  <script type="module" src="auth.js"></script>
+  <script type="module" src="student-dashboard.js"></script>
+</body>
+</html>

--- a/student-dashboard.js
+++ b/student-dashboard.js
@@ -1,0 +1,172 @@
+import { auth } from './auth.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js';
+
+const availableClasses = [
+  { id: 1, name: 'Hip Hop Basics', type: 'Hip Hop', date: '2024-08-05', time: '6:00 PM', location: 'Studio A' },
+  { id: 2, name: 'Shuffle Drills', type: 'Shuffle', date: '2024-08-06', time: '7:00 PM', location: 'Studio B' },
+  { id: 3, name: 'Contemporary Flow', type: 'Contemporary', date: '2024-08-07', time: '5:30 PM', location: 'Studio A' },
+];
+
+const upcomingEvents = [
+  { id: 1, title: 'Community Jam', date: '2024-08-15', location: 'Tempe Park' },
+  { id: 2, title: 'Fall Showcase', date: '2024-09-20', location: 'Main Theater' }
+];
+
+let schedule = [];
+let journalEntries = [];
+
+function getStorageKey(key) {
+  const user = auth.currentUser;
+  return user ? `${key}-${user.uid}` : key;
+}
+
+function loadStoredData() {
+  const sched = localStorage.getItem(getStorageKey('schedule'));
+  const journal = localStorage.getItem(getStorageKey('journal'));
+  schedule = sched ? JSON.parse(sched) : [];
+  journalEntries = journal ? JSON.parse(journal) : [];
+}
+
+function storeData() {
+  localStorage.setItem(getStorageKey('schedule'), JSON.stringify(schedule));
+  localStorage.setItem(getStorageKey('journal'), JSON.stringify(journalEntries));
+}
+
+function renderClasses(classes) {
+  const list = document.getElementById('classList');
+  list.innerHTML = '';
+  classes.forEach(c => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${c.name}</strong> - ${c.date} ${c.time} @ ${c.location}
+      <button data-id="${c.id}" class="book-btn">Book</button>`;
+    list.appendChild(li);
+  });
+}
+
+function renderSchedule() {
+  const list = document.getElementById('scheduleList');
+  list.innerHTML = '';
+  if (!schedule.length) {
+    list.innerHTML = '<li>No classes booked.</li>';
+    return;
+  }
+  schedule.forEach(c => {
+    const li = document.createElement('li');
+    li.innerHTML = `${c.name} - ${c.date} ${c.time} @ ${c.location}
+      <button data-id="${c.id}" class="cancel-btn">Cancel</button>`;
+    list.appendChild(li);
+  });
+}
+
+function renderEvents() {
+  const list = document.getElementById('eventsList');
+  list.innerHTML = '';
+  upcomingEvents.forEach(e => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${e.title}</strong> - ${e.date} @ ${e.location}
+      <button class="rsvp-btn">RSVP</button>`;
+    list.appendChild(li);
+  });
+}
+
+function renderJournal() {
+  const textarea = document.getElementById('journalText');
+  textarea.value = '';
+}
+
+function updateChart() {
+  const ctx = document.getElementById('moodChart');
+  if (!ctx) return;
+  const labels = journalEntries.map(e => e.date);
+  const moods = journalEntries.map(e => e.mood);
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{ label: 'Mood', data: moods, borderColor: '#764ba2', fill: false }]
+    },
+    options: {
+      scales: { y: { beginAtZero: true, max: 5 } }
+    }
+  });
+}
+
+function addJournalEntry() {
+  const mood = parseInt(document.getElementById('moodSelect').value, 10);
+  const text = document.getElementById('journalText').value.trim();
+  const date = new Date().toISOString().slice(0,10);
+  journalEntries.push({ date, mood, text });
+  storeData();
+  updateChart();
+  renderJournal();
+}
+
+function generateInsights() {
+  const insightsEl = document.getElementById('insights');
+  if (!journalEntries.length) {
+    insightsEl.textContent = 'Book some classes and log your mood to see insights.';
+    return;
+  }
+  const avgMood = journalEntries.reduce((sum,e)=>sum+e.mood,0)/journalEntries.length;
+  const attendance = schedule.length;
+  insightsEl.innerHTML = `<p>Average mood: ${avgMood.toFixed(1)}/5</p>
+    <p>Classes booked: ${attendance}</p>
+    <p>Keep attending regularly and tracking your wellness!</p>`;
+}
+
+function setupEventListeners() {
+  document.getElementById('classList').addEventListener('click', e => {
+    if (e.target.classList.contains('book-btn')) {
+      const id = parseInt(e.target.dataset.id, 10);
+      const cls = availableClasses.find(c => c.id === id);
+      if (cls && !schedule.find(s => s.id === id)) {
+        schedule.push(cls);
+        storeData();
+        renderSchedule();
+        generateInsights();
+      }
+    }
+  });
+
+  document.getElementById('scheduleList').addEventListener('click', e => {
+    if (e.target.classList.contains('cancel-btn')) {
+      const id = parseInt(e.target.dataset.id, 10);
+      schedule = schedule.filter(c => c.id !== id);
+      storeData();
+      renderSchedule();
+      generateInsights();
+    }
+  });
+
+  document.getElementById('saveJournal').addEventListener('click', () => {
+    addJournalEntry();
+    generateInsights();
+  });
+
+  document.getElementById('classFilter').addEventListener('change', e => {
+    const type = e.target.value;
+    const filtered = type === 'All' ? availableClasses : availableClasses.filter(c => c.type === type);
+    renderClasses(filtered);
+  });
+}
+
+function initDashboard() {
+  document.getElementById('userEmail').textContent = auth.currentUser.email;
+  document.getElementById('membershipStatus').textContent = 'Active Member';
+  loadStoredData();
+  renderClasses(availableClasses);
+  renderSchedule();
+  renderEvents();
+  renderJournal();
+  updateChart();
+  generateInsights();
+  setupEventListeners();
+}
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'login.html';
+  } else {
+    initDashboard();
+  }
+});


### PR DESCRIPTION
## Summary
- create student-dashboard.html with sections for booking, schedule, events, wellness journal, AI insights, and profile
- add student-dashboard.js for mock data, booking/schedule logic, wellness tracking, chart, and insights
- document Student Dashboard in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `git push origin main` *(fails: remote not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6853a4b88c8883239bb1d1a5ccf81953