### PR TITLE
Add forecast agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This repo defines a set of lightweight AI/automation agents. Each agent logs its
 | insights-agent | agents/insights-agent.js | Summarizes recent bookings and logs top day and class trends. |
 | anomaly-agent | agents/anomaly-agent.js | Detects spikes in bookings by day, class, or instructor using z-score heuristics. |
 | trends-agent | agents/trends-agent.js | Reports booking trends over the last 30/60/90 days by class, weekday, and instructor. |
+| forecast-agent | agents/forecast-agent.js | Generates 30-day booking forecasts per class with confidence notes. |
 
 ## Operating Standards
 

--- a/agents/forecast-agent.js
+++ b/agents/forecast-agent.js
@@ -1,0 +1,111 @@
+// forecast-agent.js
+// Generates 30-day booking forecasts for each class using a simple moving average.
+// Designed for clarity and global reuse. Logs results to data/logs.json.
+
+const fs = require('fs');
+const path = require('path');
+
+const bookingsFile = path.join(__dirname, '..', 'data', 'bookings.json');
+const logFile = path.join(__dirname, '..', 'data', 'logs.json');
+
+// ---------- Utility Functions ----------
+// Read JSON from a file. Returns an empty array on error.
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file));
+  } catch (e) {
+    return [];
+  }
+}
+
+// Write JSON to a file with indentation for readability.
+function writeJson(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+// Append an action entry to the shared log file.
+function logAction(action, details) {
+  const logs = readJson(logFile);
+  logs.push({ time: new Date().toISOString(), action, details });
+  writeJson(logFile, logs);
+}
+
+// ---------- Forecast Logic ----------
+
+// Build an array of daily booking counts for the last `lookbackDays` days.
+// Each index represents a day relative to today.
+function buildDailyCounts(bookings, lookbackDays) {
+  const counts = Array(lookbackDays).fill(0);
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - lookbackDays + 1);
+
+  bookings.forEach(b => {
+    if (!b.date) return;
+    const d = new Date(b.date);
+    if (d >= start) {
+      const idx = Math.floor((d - start) / 86400000);
+      if (idx >= 0 && idx < lookbackDays) {
+        counts[idx] += 1;
+      }
+    }
+  });
+  return counts;
+}
+
+// Generate forecast details for a single class.
+function forecastForClass(bookings, classType, lookbackDays, horizonDays) {
+  const classBookings = bookings.filter(b => b.classType === classType);
+  const counts = buildDailyCounts(classBookings, lookbackDays);
+  const total = counts.reduce((a, b) => a + b, 0);
+  const sampleDays = counts.filter(c => c > 0).length;
+
+  // Fallback: if there is not enough data, return zeros and note the issue.
+  if (total === 0 || sampleDays < 3) {
+    return {
+      classType,
+      forecast: Array(horizonDays).fill(0),
+      confidence: 'low',
+      notes: 'Insufficient recent data; forecast defaults to 0 for all days.'
+    };
+  }
+
+  const mean = total / lookbackDays;
+  const variance = counts.reduce((sum, c) => sum + Math.pow(c - mean, 2), 0) / lookbackDays;
+  const sd = Math.sqrt(variance);
+
+  let confidence = 'medium';
+  if (sampleDays >= 10 && sd / mean < 0.3) confidence = 'high';
+  else if (sampleDays < 5) confidence = 'low';
+
+  return {
+    classType,
+    forecast: Array(horizonDays).fill(parseFloat(mean.toFixed(2))),
+    confidence,
+    notes: `Forecast uses a ${lookbackDays}-day moving average based on ${sampleDays} days of data.`
+  };
+}
+
+// Produce forecasts for all classes in the bookings list.
+function forecastBookings(bookings, lookbackDays = 30, horizonDays = 30) {
+  const classes = Array.from(new Set(bookings.map(b => b.classType).filter(Boolean)));
+  return classes.map(c => forecastForClass(bookings, c, lookbackDays, horizonDays));
+}
+
+// Run the agent using the stored bookings file and log the results.
+function run() {
+  const bookings = readJson(bookingsFile);
+  if (!bookings.length) {
+    console.log('No bookings available for forecasting');
+    return;
+  }
+  const results = forecastBookings(bookings);
+  logAction('booking_forecast', JSON.stringify(results));
+  console.log(JSON.stringify(results, null, 2));
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = { run, forecastBookings };

--- a/tests/forecast-agent.test.js
+++ b/tests/forecast-agent.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { forecastBookings } = require('../agents/forecast-agent');
+
+// Build mock bookings for two classes
+const bookings = [];
+const today = new Date();
+today.setHours(0,0,0,0);
+for (let i = 0; i < 7; i++) {
+  const d = new Date(today);
+  d.setDate(d.getDate() - (6 - i));
+  const date = d.toISOString().slice(0,10);
+  // Ballet has two bookings every day
+  bookings.push({ date, classType: 'Ballet' });
+  bookings.push({ date, classType: 'Ballet' });
+  // Hip Hop only on first three days
+  if (i < 3) {
+    bookings.push({ date, classType: 'Hip Hop' });
+  }
+}
+
+const results = forecastBookings(bookings, 7, 30);
+
+const ballet = results.find(r => r.classType === 'Ballet');
+assert.ok(ballet, 'Ballet forecast missing');
+assert.strictEqual(Math.round(ballet.forecast[0]), 2, 'Ballet forecast should be ~2');
+
+const hiphop = results.find(r => r.classType === 'Hip Hop');
+assert.ok(hiphop, 'Hip Hop forecast missing');
+assert.strictEqual(hiphop.confidence, 'low', 'Hip Hop confidence should be low due to limited data');
+
+console.log('forecast-agent tests passed');


### PR DESCRIPTION
## Summary
- create `forecast-agent.js` to generate 30-day booking forecasts
- register new agent in `AGENTS.md`
- add Jest-style unit test for forecast agent

## Testing
- `node tests/anomaly-agent.test.js`
- `node tests/trends-agent.test.js`
- `node tests/forecast-agent.test.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bf53a0b883239ff6d667c9d8c1c0