### PR TITLE
Add admin insights dashboard

### DIFF
--- a/dashboard-insights.html
+++ b/dashboard-insights.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Insights - Hybrid Dancers</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    .insights-page { padding: 2rem; max-width: 800px; margin: 0 auto; }
+    .insight-section { margin-bottom: 2rem; }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-container">
+      <div class="logo">Hybrid Dancers</div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="instructor.html">Instructor</a></li>
+        <li class="account-link"><a href="login.html">Log In</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="insights-page">
+    <h2>Latest AI Insights</h2>
+    <p id="lastUpdated"></p>
+
+    <div id="anomaly" class="insight-section">
+      <h3>Recent Anomalies</h3>
+      <ul id="anomalyList"></ul>
+    </div>
+
+    <div id="forecast" class="insight-section">
+      <h3>Forecasted Demand</h3>
+      <ul id="forecastList"></ul>
+    </div>
+
+    <div id="attendance" class="insight-section">
+      <h3>Attendance Patterns</h3>
+      <ul id="attendanceList"></ul>
+    </div>
+  </main>
+
+  <script type="module" src="scripts/dashboard-insights.js"></script>
+</body>
+</html>

--- a/scripts/dashboard-insights.js
+++ b/scripts/dashboard-insights.js
@@ -1,0 +1,122 @@
+// dashboard-insights.js
+// Fetch logs from /api/logs and display summaries for admin users.
+// The logic intentionally avoids complex frameworks to remain lightweight
+// and easy for non-technical staff to read.
+
+async function fetchLogs() {
+  try {
+    const resp = await fetch('/api/logs');
+    if (!resp.ok) return [];
+    return await resp.json();
+  } catch (e) {
+    console.error('Failed to load logs', e);
+    return [];
+  }
+}
+
+// Find the most recent log entry for each action type
+function latestByAction(logs, action) {
+  for (let i = logs.length - 1; i >= 0; i--) {
+    if (logs[i].action === action) return logs[i];
+  }
+  return null;
+}
+
+function formatDateTime(iso) {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch (_) {
+    return iso;
+  }
+}
+
+function renderAttendance(log) {
+  const list = document.getElementById('attendanceList');
+  if (!log) {
+    list.innerHTML = '<li>No attendance data found.</li>';
+    return;
+  }
+  const dates = log.details ? log.details.split(',') : [];
+  if (!dates.length) {
+    list.innerHTML = '<li>No low attendance dates recorded.</li>';
+    return;
+  }
+  list.innerHTML = '';
+  dates.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = `Low attendance on ${d}`;
+    list.appendChild(li);
+  });
+}
+
+function renderAnomalies(log) {
+  const list = document.getElementById('anomalyList');
+  if (!log) {
+    list.innerHTML = '<li>No anomalies detected.</li>';
+    return;
+  }
+  let anomalies;
+  try {
+    anomalies = JSON.parse(log.details);
+  } catch (_) {
+    anomalies = [];
+  }
+  if (!Array.isArray(anomalies) || !anomalies.length) {
+    list.innerHTML = '<li>No anomalies detected.</li>';
+    return;
+  }
+  list.innerHTML = '';
+  anomalies.forEach(a => {
+    const li = document.createElement('li');
+    li.textContent = a.reason || `${a.dimension} ${a.label} had an anomaly`;
+    list.appendChild(li);
+  });
+}
+
+function renderForecast(log) {
+  const list = document.getElementById('forecastList');
+  if (!log) {
+    list.innerHTML = '<li>No forecast data available.</li>';
+    return;
+  }
+  let forecasts;
+  try {
+    forecasts = JSON.parse(log.details);
+  } catch (_) {
+    forecasts = [];
+  }
+  if (!Array.isArray(forecasts) || !forecasts.length) {
+    list.innerHTML = '<li>No forecast data available.</li>';
+    return;
+  }
+  list.innerHTML = '';
+  forecasts.forEach(f => {
+    const li = document.createElement('li');
+    const avg = f.forecast && f.forecast[0] ? f.forecast[0] : 0;
+    li.textContent = `${f.classType}: ~${avg} bookings/day (${f.confidence} confidence)`;
+    list.appendChild(li);
+  });
+}
+
+async function init() {
+  const logs = await fetchLogs();
+  if (!Array.isArray(logs)) return;
+
+  // Sort by time to ensure latest entries are last
+  logs.sort((a, b) => new Date(a.time) - new Date(b.time));
+
+  renderAttendance(latestByAction(logs, 'attendance_anomaly'));
+  renderAnomalies(latestByAction(logs, 'anomaly_detected'));
+  renderForecast(latestByAction(logs, 'booking_forecast'));
+
+  // Show timestamp of last update
+  const ts = latestByAction(logs, 'booking_forecast')?.time ||
+             latestByAction(logs, 'anomaly_detected')?.time ||
+             latestByAction(logs, 'attendance_anomaly')?.time;
+  if (ts) {
+    const p = document.getElementById('lastUpdated');
+    if (p) p.textContent = `Last updated: ${formatDateTime(ts)}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- create `dashboard-insights.html` to show recent AI insights for admins
- add `scripts/dashboard-insights.js` to fetch `/api/logs` and render summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c1ce68b48323995f11df2e98bb6d