### PR TITLE
Add charts and filters to insights dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Remove any existing records that point to GitHub Pages or other providers (for e
 
 Open the file in your browser (or deploy it alongside the site) and sign in to access these tools.
 
+## 📊 Insights Dashboard
+
+`dashboard-insights.html` gives administrators a quick view of recent AI agent outputs. The page now includes:
+
+- Charts for anomalies, booking forecasts and attendance patterns powered by Chart.js
+- Filters to narrow insights by class, instructor or date range
+- Locale-aware timestamps (US/EU) and a CSV export button for further analysis
+
+Load the page after running the agents to explore trends and download the raw data.
+
 ## 🎓 Student Dashboard
 
 `student-dashboard.html` lets each student manage their classes and wellbeing. After logging in you can:

--- a/dashboard-insights.html
+++ b/dashboard-insights.html
@@ -5,9 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin Insights - Hybrid Dancers</title>
   <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
-    .insights-page { padding: 2rem; max-width: 800px; margin: 0 auto; }
+    .insights-page { padding: 2rem; max-width: 900px; margin: 0 auto; }
     .insight-section { margin-bottom: 2rem; }
+    .filters { display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:1rem; }
+    .filters label { display:flex; flex-direction:column; font-size:0.9rem; }
   </style>
 </head>
 <body>
@@ -25,21 +28,49 @@
 
   <main class="insights-page">
     <h2>Latest AI Insights</h2>
+    <div class="filters">
+      <label>Class
+        <select id="filterClass">
+          <option value="">All</option>
+        </select>
+      </label>
+      <label>Instructor
+        <select id="filterInstructor">
+          <option value="">All</option>
+        </select>
+      </label>
+      <label>Start
+        <input type="date" id="filterStart">
+      </label>
+      <label>End
+        <input type="date" id="filterEnd">
+      </label>
+      <label>Locale
+        <select id="localeSelect">
+          <option value="en-US">US</option>
+          <option value="de-DE">EU</option>
+        </select>
+      </label>
+      <button id="exportCsv">Export CSV</button>
+    </div>
     <p id="lastUpdated"></p>
 
     <div id="anomaly" class="insight-section">
       <h3>Recent Anomalies</h3>
       <ul id="anomalyList"></ul>
+      <canvas id="anomalyChart" height="100"></canvas>
     </div>
 
     <div id="forecast" class="insight-section">
       <h3>Forecasted Demand</h3>
       <ul id="forecastList"></ul>
+      <canvas id="forecastChart" height="100"></canvas>
     </div>
 
     <div id="attendance" class="insight-section">
       <h3>Attendance Patterns</h3>
       <ul id="attendanceList"></ul>
+      <canvas id="attendanceChart" height="100"></canvas>
     </div>
   </main>
 

--- a/scripts/dashboard-insights.js
+++ b/scripts/dashboard-insights.js
@@ -1,7 +1,7 @@
 // dashboard-insights.js
-// Fetch logs from /api/logs and display summaries for admin users.
-// The logic intentionally avoids complex frameworks to remain lightweight
-// and easy for non-technical staff to read.
+// Fetch logs from /api/logs and display summaries for admin users with
+// simple charts, filters and CSV export. Functions are exported for tests
+// but DOM manipulation only runs in the browser environment.
 
 async function fetchLogs() {
   try {
@@ -14,6 +14,64 @@ async function fetchLogs() {
   }
 }
 
+// Convert log entries into a form easier to filter and display.
+function parseLogs(logs) {
+  return logs.map(l => {
+    let parsedDetails;
+    try {
+      if (l.action === 'anomaly_detected' || l.action === 'booking_forecast') {
+        parsedDetails = JSON.parse(l.details);
+      } else if (l.action === 'attendance_anomaly') {
+        parsedDetails = l.details ? l.details.split(',') : [];
+      } else {
+        parsedDetails = l.details;
+      }
+    } catch (_) {
+      parsedDetails = l.details;
+    }
+    return { ...l, parsedDetails };
+  });
+}
+
+// Apply simple filters to parsed logs.
+function filterLogs(logs, opts = {}) {
+  const { classType, instructor, startDate, endDate } = opts;
+  return logs.filter(l => {
+    const t = new Date(l.time);
+    if (startDate && t < new Date(startDate)) return false;
+    if (endDate && t > new Date(endDate)) return false;
+    if (classType) {
+      if (l.action === 'booking_forecast') {
+        return l.parsedDetails.some(f => f.classType === classType);
+      }
+      if (l.action === 'anomaly_detected') {
+        return l.parsedDetails.some(a => a.dimension === 'class' && a.label === classType);
+      }
+      return false;
+    }
+    if (instructor && l.action === 'anomaly_detected') {
+      return l.parsedDetails.some(a => a.dimension === 'instructor' && a.label === instructor);
+    }
+    if (instructor) return false;
+    return true;
+  });
+}
+
+// Turn logs into a CSV string for downloading.
+function logsToCsv(logs) {
+  const header = 'time,action,details\n';
+  const rows = logs.map(l => {
+    const det = typeof l.parsedDetails === 'string' ? l.parsedDetails : JSON.stringify(l.parsedDetails);
+    return `${l.time},${l.action},${det.replace(/\n/g,' ')}`;
+  });
+  return header + rows.join('\n');
+}
+
+let parsedLogs = [];
+let filteredLogs = [];
+let locale = (typeof navigator !== 'undefined' && navigator.language && navigator.language.startsWith('de')) ? 'de-DE' : 'en-US';
+let attendanceChart, anomalyChart, forecastChart;
+
 // Find the most recent log entry for each action type
 function latestByAction(logs, action) {
   for (let i = logs.length - 1; i >= 0; i--) {
@@ -24,7 +82,7 @@ function latestByAction(logs, action) {
 
 function formatDateTime(iso) {
   try {
-    return new Date(iso).toLocaleString();
+    return new Date(iso).toLocaleString(locale);
   } catch (_) {
     return iso;
   }
@@ -32,91 +90,193 @@ function formatDateTime(iso) {
 
 function renderAttendance(log) {
   const list = document.getElementById('attendanceList');
+  const canvas = document.getElementById('attendanceChart');
   if (!log) {
-    list.innerHTML = '<li>No attendance data found.</li>';
+    list.innerHTML = '<li>No attendance data found. Run the attendance agent to collect stats.</li>';
+    if (attendanceChart) attendanceChart.destroy();
     return;
   }
-  const dates = log.details ? log.details.split(',') : [];
+  const dates = Array.isArray(log.parsedDetails) ? log.parsedDetails : [];
   if (!dates.length) {
     list.innerHTML = '<li>No low attendance dates recorded.</li>';
+    if (attendanceChart) attendanceChart.destroy();
     return;
   }
   list.innerHTML = '';
+  const counts = {};
   dates.forEach(d => {
+    counts[d] = (counts[d] || 0) + 1;
     const li = document.createElement('li');
     li.textContent = `Low attendance on ${d}`;
     list.appendChild(li);
+  });
+  const labels = Object.keys(counts);
+  const data = labels.map(l => counts[l]);
+  if (attendanceChart) attendanceChart.destroy();
+  attendanceChart = new Chart(canvas, {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Low Attendance', data, backgroundColor: '#ff6b6b' }] },
+    options: { scales: { y: { beginAtZero: true } } }
   });
 }
 
 function renderAnomalies(log) {
   const list = document.getElementById('anomalyList');
+  const canvas = document.getElementById('anomalyChart');
   if (!log) {
     list.innerHTML = '<li>No anomalies detected.</li>';
+    if (anomalyChart) anomalyChart.destroy();
     return;
   }
-  let anomalies;
-  try {
-    anomalies = JSON.parse(log.details);
-  } catch (_) {
-    anomalies = [];
-  }
-  if (!Array.isArray(anomalies) || !anomalies.length) {
+  const anomalies = Array.isArray(log.parsedDetails) ? log.parsedDetails : [];
+  if (!anomalies.length) {
     list.innerHTML = '<li>No anomalies detected.</li>';
+    if (anomalyChart) anomalyChart.destroy();
     return;
   }
   list.innerHTML = '';
+  const counts = {};
   anomalies.forEach(a => {
+    counts[a.label] = (counts[a.label] || 0) + 1;
     const li = document.createElement('li');
-    li.textContent = a.reason || `${a.dimension} ${a.label} had an anomaly`;
+    li.textContent = a.reason || `${a.dimension} ${a.label} anomaly`;
     list.appendChild(li);
+  });
+  const labels = Object.keys(counts);
+  const data = labels.map(l => counts[l]);
+  if (anomalyChart) anomalyChart.destroy();
+  anomalyChart = new Chart(canvas, {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Anomalies', data, backgroundColor: '#48dbfb' }] },
+    options: { scales: { y: { beginAtZero: true } } }
   });
 }
 
 function renderForecast(log) {
   const list = document.getElementById('forecastList');
+  const canvas = document.getElementById('forecastChart');
   if (!log) {
     list.innerHTML = '<li>No forecast data available.</li>';
+    if (forecastChart) forecastChart.destroy();
     return;
   }
-  let forecasts;
-  try {
-    forecasts = JSON.parse(log.details);
-  } catch (_) {
-    forecasts = [];
-  }
-  if (!Array.isArray(forecasts) || !forecasts.length) {
+  const forecasts = Array.isArray(log.parsedDetails) ? log.parsedDetails : [];
+  if (!forecasts.length) {
     list.innerHTML = '<li>No forecast data available.</li>';
+    if (forecastChart) forecastChart.destroy();
     return;
   }
   list.innerHTML = '';
+  const labels = [];
+  const data = [];
   forecasts.forEach(f => {
-    const li = document.createElement('li');
     const avg = f.forecast && f.forecast[0] ? f.forecast[0] : 0;
+    labels.push(f.classType);
+    data.push(avg);
+    const li = document.createElement('li');
     li.textContent = `${f.classType}: ~${avg} bookings/day (${f.confidence} confidence)`;
     list.appendChild(li);
+  });
+  if (forecastChart) forecastChart.destroy();
+  forecastChart = new Chart(canvas, {
+    type: 'bar',
+    data: { labels, datasets: [{ label: 'Forecast Next Day', data, backgroundColor: '#1dd1a1' }] },
+    options: { scales: { y: { beginAtZero: true } } }
   });
 }
 
 async function init() {
-  const logs = await fetchLogs();
-  if (!Array.isArray(logs)) return;
+  const raw = await fetchLogs();
+  if (!Array.isArray(raw)) return;
 
-  // Sort by time to ensure latest entries are last
-  logs.sort((a, b) => new Date(a.time) - new Date(b.time));
+  raw.sort((a, b) => new Date(a.time) - new Date(b.time));
+  parsedLogs = parseLogs(raw);
+  filteredLogs = parsedLogs;
+  populateFilters();
+  applyFilters();
 
-  renderAttendance(latestByAction(logs, 'attendance_anomaly'));
-  renderAnomalies(latestByAction(logs, 'anomaly_detected'));
-  renderForecast(latestByAction(logs, 'booking_forecast'));
+  const localeSelect = document.getElementById('localeSelect');
+  if (localeSelect) localeSelect.value = locale;
 
-  // Show timestamp of last update
-  const ts = latestByAction(logs, 'booking_forecast')?.time ||
-             latestByAction(logs, 'anomaly_detected')?.time ||
-             latestByAction(logs, 'attendance_anomaly')?.time;
-  if (ts) {
-    const p = document.getElementById('lastUpdated');
-    if (p) p.textContent = `Last updated: ${formatDateTime(ts)}`;
+  ['filterClass','filterInstructor','filterStart','filterEnd','localeSelect'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('change', applyFilters);
+  });
+
+  const exportBtn = document.getElementById('exportCsv');
+  if (exportBtn) exportBtn.addEventListener('click', () => {
+    const csv = logsToCsv(filteredLogs);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'insights.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+}
+
+function populateFilters() {
+  const classSet = new Set();
+  const instructorSet = new Set();
+  parsedLogs.forEach(l => {
+    if (l.action === 'booking_forecast') {
+      l.parsedDetails.forEach(f => classSet.add(f.classType));
+    }
+    if (l.action === 'anomaly_detected') {
+      l.parsedDetails.forEach(a => {
+        if (a.dimension === 'class') classSet.add(a.label);
+        if (a.dimension === 'instructor') instructorSet.add(a.label);
+      });
+    }
+  });
+  const classSel = document.getElementById('filterClass');
+  const instrSel = document.getElementById('filterInstructor');
+  if (classSel) {
+    classSet.forEach(c => {
+      if (!Array.from(classSel.options).some(o => o.value === c)) {
+        const opt = document.createElement('option');
+        opt.value = c; opt.textContent = c; classSel.appendChild(opt);
+      }
+    });
+  }
+  if (instrSel) {
+    instructorSet.forEach(i => {
+      if (!Array.from(instrSel.options).some(o => o.value === i)) {
+        const opt = document.createElement('option');
+        opt.value = i; opt.textContent = i; instrSel.appendChild(opt);
+      }
+    });
   }
 }
 
-document.addEventListener('DOMContentLoaded', init);
+function applyFilters() {
+  const classType = document.getElementById('filterClass')?.value || '';
+  const instructor = document.getElementById('filterInstructor')?.value || '';
+  const startDate = document.getElementById('filterStart')?.value || '';
+  const endDate = document.getElementById('filterEnd')?.value || '';
+  const localeSel = document.getElementById('localeSelect');
+  if (localeSel) locale = localeSel.value;
+
+  filteredLogs = filterLogs(parsedLogs, { classType: classType || null, instructor: instructor || null, startDate: startDate || null, endDate: endDate || null });
+
+  renderAttendance(latestByAction(filteredLogs, 'attendance_anomaly'));
+  renderAnomalies(latestByAction(filteredLogs, 'anomaly_detected'));
+  renderForecast(latestByAction(filteredLogs, 'booking_forecast'));
+
+  const ts = latestByAction(filteredLogs, 'booking_forecast')?.time ||
+             latestByAction(filteredLogs, 'anomaly_detected')?.time ||
+             latestByAction(filteredLogs, 'attendance_anomaly')?.time;
+  const p = document.getElementById('lastUpdated');
+  if (p) {
+    p.textContent = ts ? `Last updated: ${formatDateTime(ts)}` : 'No data available.';
+  }
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', init);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { parseLogs, filterLogs, logsToCsv };
+}

--- a/tests/dashboard-insights.test.js
+++ b/tests/dashboard-insights.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { parseLogs, filterLogs, logsToCsv } = require('../scripts/dashboard-insights.js');
+
+const sampleLogs = [
+  { time: '2023-09-01T00:00:00Z', action: 'attendance_anomaly', details: '2023-08-31' },
+  { time: '2023-09-02T00:00:00Z', action: 'anomaly_detected', details: '[{"dimension":"class","label":"Salsa"}]' },
+  { time: '2023-09-03T00:00:00Z', action: 'booking_forecast', details: '[{"classType":"Salsa","forecast":[5],"confidence":"high"}]' }
+];
+
+const parsed = parseLogs(sampleLogs);
+
+const filtered = filterLogs(parsed, { classType: 'Salsa' });
+assert.strictEqual(filtered.length, 2, 'Filter by class should return matching entries');
+
+const csv = logsToCsv(filtered);
+assert.ok(csv.includes('Salsa'), 'CSV should include class type');
+
+console.log('dashboard-insights tests passed');


### PR DESCRIPTION
## Summary
- expand `dashboard-insights.html` with filter UI, charts and CSV export
- overhaul `dashboard-insights.js` to parse logs, draw charts and support filters
- document the new features in `README.md`
- add tests for insights dashboard utilities

## Testing
- `node tests/anomaly-agent.test.js`
- `node tests/forecast-agent.test.js`
- `node tests/trends-agent.test.js`
- `node tests/dashboard-insights.test.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c3e42d308323a50a87bc6f81902f