### PR TITLE
Use CONFIG global for frontend keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ The Express server now stores bookings in `data/bookings.json` and exposes a sma
 
 Agent scripts under `agents/` can analyze this data. Run `node agents/attendance-agent.js` to log attendance anomalies.
 
+## ⚙️ Runtime Configuration
+
+Client-side scripts expect a global `window.CONFIG` object containing your Stripe and Firebase keys. You can serve these values dynamically from Express by adding a route:
+
+```javascript
+app.get('/config.js', (req, res) => {
+  res.type('js').send(`window.CONFIG = ${JSON.stringify({
+    STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,
+    FIREBASE_API_KEY: process.env.FIREBASE_API_KEY,
+    FIREBASE_AUTH_DOMAIN: process.env.FIREBASE_AUTH_DOMAIN,
+    FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID,
+    FIREBASE_STORAGE_BUCKET: process.env.FIREBASE_STORAGE_BUCKET,
+    FIREBASE_MESSAGING_SENDER_ID: process.env.FIREBASE_MESSAGING_SENDER_ID,
+    FIREBASE_APP_ID: process.env.FIREBASE_APP_ID,
+    FIREBASE_MEASUREMENT_ID: process.env.FIREBASE_MEASUREMENT_ID
+  })};`);
+});
+```
+
+Include the generated `config.js` before your other scripts:
+
+```html
+<script src="/config.js"></script>
+```
+
 ## 🌐 Custom Domain with Firebase Hosting
 
 To serve the site on `www.hybriddancers.com`, configure your DNS records as follows:

--- a/auth.js
+++ b/auth.js
@@ -12,9 +12,9 @@ import {
 // hard-coding credentials in source control. When bundling this script,
 // provide the values via your build tool or server.
 const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY || '',
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN || '',
-  projectId: process.env.FIREBASE_PROJECT_ID || ''
+  apiKey: window.CONFIG?.FIREBASE_API_KEY || '',
+  authDomain: window.CONFIG?.FIREBASE_AUTH_DOMAIN || '',
+  projectId: window.CONFIG?.FIREBASE_PROJECT_ID || ''
 };
 
 // Initialize Firebase

--- a/booking.js
+++ b/booking.js
@@ -1,6 +1,6 @@
 // The Stripe public key should be injected by the server or build tool.
 // Fallback to an empty string to avoid accidental key leakage.
-const stripe = Stripe(window.STRIPE_PUBLIC_KEY || process.env.STRIPE_PUBLIC_KEY || '');
+const stripe = Stripe(window.CONFIG?.STRIPE_PUBLIC_KEY || '');
 
 document.getElementById('booking-form').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/firebase.js
+++ b/firebase.js
@@ -5,13 +5,13 @@ import { getAnalytics } from "firebase/analytics";
 // Firebase configuration should be provided via environment variables.
 // This prevents leaking credentials in the repository.
 const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY || '',
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN || '',
-  projectId: process.env.FIREBASE_PROJECT_ID || '',
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || '',
-  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID || '',
-  appId: process.env.FIREBASE_APP_ID || '',
-  measurementId: process.env.FIREBASE_MEASUREMENT_ID || ''
+  apiKey: window.CONFIG?.FIREBASE_API_KEY || '',
+  authDomain: window.CONFIG?.FIREBASE_AUTH_DOMAIN || '',
+  projectId: window.CONFIG?.FIREBASE_PROJECT_ID || '',
+  storageBucket: window.CONFIG?.FIREBASE_STORAGE_BUCKET || '',
+  messagingSenderId: window.CONFIG?.FIREBASE_MESSAGING_SENDER_ID || '',
+  appId: window.CONFIG?.FIREBASE_APP_ID || '',
+  measurementId: window.CONFIG?.FIREBASE_MEASUREMENT_ID || ''
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary
- read Firebase and Stripe config from `window.CONFIG`
- document `window.CONFIG` usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c9295eec8323b66dbd2e2440b085