### PR TITLE
Add HTTPS enforcement middleware

### DIFF
--- a/docs/ROADMAP_CHECKLIST.md
+++ b/docs/ROADMAP_CHECKLIST.md
@@ -3,7 +3,7 @@
 The following tasks summarize the short-term goals outlined in `TECHNICAL_ROADMAP.md`.
 
 - [ ] Clean up API keys and rely solely on environment variables
-- [ ] Enforce HTTPS for all routes and assets
+- [x] Enforce HTTPS for all routes and assets
 - [ ] Publish a privacy policy and terms of service
 - [ ] Extend automated tests for booking and auth flows
 - [ ] Improve mobile user experience and layout

--- a/server.js
+++ b/server.js
@@ -7,6 +7,14 @@ const { nanoid } = require('nanoid');
 
 const app = express();
 app.use(express.json());
+if (process.env.NODE_ENV !== 'development') {
+  app.use((req, res, next) => {
+    if (!req.secure && req.get('x-forwarded-proto') !== 'https') {
+      return res.redirect('https://' + req.headers.host + req.url);
+    }
+    next();
+  });
+}
 app.use(express.static(path.join(__dirname)));
 
 const bookingsFile = path.join(__dirname, 'data', 'bookings.json');


### PR DESCRIPTION
## Summary
- redirect HTTP requests to HTTPS in production mode
- mark HTTPS enforcement task complete on roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c92b40d083238e000228d377e83a