### PR TITLE
Add email confirmations for class registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ The Express server now stores bookings in `data/bookings.json` and exposes a sma
 
 Agent scripts under `agents/` can analyze this data. Run `node agents/attendance-agent.js` to log attendance anomalies.
 
+### Email Confirmation Setup
+
+`functions/registerForClass` sends confirmation emails via Nodemailer after saving a registration. Provide credentials for one of the services below:
+
+#### Gmail
+- GMAIL_USER – your Gmail address
+- GMAIL_PASS – app password for the account
+
+#### SendGrid
+- SENDGRID_API_KEY – your SendGrid API key
+
+Optionally set EMAIL_FROM to override the sender address.
+
+
 ## ⚙️ Runtime Configuration
 
 Client-side scripts expect a global `window.CONFIG` object containing your Stripe and Firebase keys. You can serve these values dynamically from Express by adding a route:

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,66 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const nodemailer = require('nodemailer');
+
+admin.initializeApp();
+const db = admin.firestore();
+
+function createTransport() {
+  if (process.env.SENDGRID_API_KEY) {
+    return nodemailer.createTransport({
+      host: 'smtp.sendgrid.net',
+      port: 587,
+      auth: { user: 'apikey', pass: process.env.SENDGRID_API_KEY }
+    });
+  }
+  return nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.GMAIL_USER,
+      pass: process.env.GMAIL_PASS
+    }
+  });
+}
+
+async function sendConfirmationEmail({ name, email, className }) {
+  const transporter = createTransport();
+  const from = process.env.EMAIL_FROM || process.env.GMAIL_USER || 'no-reply@hybriddancers.com';
+  const mailOptions = {
+    from,
+    to: email,
+    subject: 'Class Registration Confirmation',
+    html: `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Registration Confirmed!</h2>
+        <p>Hi ${name},</p>
+        <p>You are confirmed for <strong>${className}</strong>.</p>
+        <p>We look forward to seeing you.</p>
+        <p>- Hybrid Dancers</p>
+      </div>
+    `
+  };
+
+  await transporter.sendMail(mailOptions);
+}
+
+exports.registerForClass = functions.https.onCall(async (data, context) => {
+  const { name, email, className } = data || {};
+  if (!name || !email || !className) {
+    throw new functions.https.HttpsError('invalid-argument', 'Missing required fields');
+  }
+
+  const docRef = await db.collection('registrations').add({
+    name,
+    email,
+    class: className,
+    created: admin.firestore.FieldValue.serverTimestamp()
+  });
+
+  try {
+    await sendConfirmationEmail({ name, email, className });
+  } catch (err) {
+    console.error('Failed to send confirmation email:', err);
+  }
+
+  return { success: true, id: docRef.id };
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hybriddancers-functions",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "nodemailer": "^6.9.6"
+  }
+}


### PR DESCRIPTION
## Summary
- create `functions` folder with Firebase function `registerForClass`
- send confirmation emails via Nodemailer using Gmail or SendGrid
- log and ignore email errors so registration still succeeds
- document environment vars for confirmation emails in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68545f40645c8323b6caebfee58c9c50