### PR TITLE
Add Calendly scheduling widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,15 +136,10 @@
             <h2 class="section-title">Ready to Move?</h2>
             <div class="schedule-placeholder">
                 <h3>📅 Book Your Class</h3>
-                <p style="margin: 1rem 0; color: #666;">
-                    Click below to view our live schedule and book your spot. Classes are filling up fast!
-                </p>
-                <div style="margin: 2rem 0;">
-                    <a href="#" class="btn btn-primary" style="margin: 0.5rem;">View Schedule & Book</a>
+                <div id="calendly-widget" class="calendly-inline-widget" data-url="https://calendly.com/hybriddancers/class?primary_color=8C1D40&text_color=2C2C2C&background_color=FFFFFF" style="min-width:320px; height:650px;"></div>
+                <div id="calendly-fallback" style="margin-top: 1rem;">
+                    <a href="https://calendly.com/hybriddancers/class" target="_blank" rel="noopener" class="btn btn-primary">Open Booking Page</a>
                 </div>
-                <p style="font-size: 0.9rem; color: #888;">
-                    Integration: Calendly or Acuity Scheduling embed goes here
-                </p>
             </div>
         </div>
     </section>
@@ -227,6 +222,7 @@
         </div>
     </footer>
 
+    <script async src="https://assets.calendly.com/assets/external/widget.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -143,4 +143,29 @@ document.addEventListener('DOMContentLoaded', () => {
             btn.style.transform = 'translateY(0)';
         });
     });
+
+    // Calendly fallback handling and click tracking
+    const fallback = document.getElementById('calendly-fallback');
+    const widget = document.getElementById('calendly-widget');
+    if (fallback && widget) {
+        const obs = new MutationObserver(() => {
+            if (widget.querySelector('iframe')) {
+                fallback.style.display = 'none';
+                obs.disconnect();
+            }
+        });
+        obs.observe(widget, { childList: true });
+        setTimeout(() => obs.disconnect(), 10000);
+
+        const link = fallback.querySelector('a');
+        if (link) {
+            link.addEventListener('click', () => {
+                fetch('/api/logs', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'booking_link_click', details: 'index_schedule' })
+                }).catch(() => {});
+            });
+        }
+    }
 });

--- a/server.js
+++ b/server.js
@@ -101,5 +101,15 @@ app.get('/api/logs', (req, res) => {
   res.json(logs);
 });
 
+app.post('/api/logs', (req, res) => {
+  const { action, details } = req.body || {};
+  if (action) {
+    logAction(action, details || '');
+    res.json({ status: 'logged' });
+  } else {
+    res.status(400).json({ error: 'action required' });
+  }
+});
+
 const PORT = process.env.PORT || 4242;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/style.css
+++ b/style.css
@@ -1314,6 +1314,18 @@
             margin-bottom: 1rem;
         }
 
+        .calendly-inline-widget {
+            width: 100%;
+            border: 2px solid var(--maroon);
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 10px 30px var(--shadow);
+        }
+
+        #calendly-fallback {
+            margin-top: 1rem;
+        }
+
         /* Community Section */
         .community {
             padding: 6rem 0;


### PR DESCRIPTION
## Summary
- integrate Calendly inline widget in the schedule section
- add responsive styling and fallback link
- track booking clicks via new `/api/logs` endpoint
- load Calendly widget script asynchronously

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859ec27dc5c8323aeccf5b71592bc68