### PR TITLE
Secure Stripe publishable key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Example environment configuration for Hybrid Dancers
 STRIPE_SECRET_KEY=sk_test_your_secret_key
 STRIPE_PUBLIC_KEY=pk_test_your_public_key
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key
 STRIPE_PRICE_ID=price_test_id
 DOMAIN_URL=http://localhost:4242
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .pytest_cache/
 node_modules/
+.env

--- a/booking.js
+++ b/booking.js
@@ -1,6 +1,9 @@
-// The Stripe public key should be injected by the server or build tool.
-// Fallback to an empty string to avoid accidental key leakage.
-const stripe = Stripe(window.CONFIG?.STRIPE_PUBLIC_KEY || '');
+let stripe;
+fetch('/config')
+  .then(r => r.json())
+  .then(data => {
+    stripe = Stripe(data.publishableKey);
+  });
 
 document.getElementById('booking-form').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/checkout.js
+++ b/checkout.js
@@ -1,6 +1,11 @@
-const stripe = Stripe(window.CONFIG?.STRIPE_PUBLIC_KEY || '');
+let stripe;
+fetch('/config')
+  .then(r => r.json())
+  .then(data => {
+    stripe = Stripe(data.publishableKey);
+  });
 
-const btn = document.getElementById('pay-class-btn');
+const btn = document.getElementById('checkout-button');
 if (btn) {
   btn.addEventListener('click', async (e) => {
     e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
                     <a href="https://calendly.com/hybriddancers/class" target="_blank" rel="noopener" class="btn btn-primary">Open Booking Page</a>
                 </div>
                 <div style="margin-top: 1rem; text-align:center;">
-                    <button id="pay-class-btn" class="btn btn-primary">Pay for Class</button>
+                    <button id="checkout-button" class="btn btn-primary">Pay for Class</button>
                     <p class="payment-note">Secure payment powered by Stripe</p>
                 </div>
             </div>

--- a/server.js
+++ b/server.js
@@ -20,6 +20,10 @@ if (process.env.NODE_ENV !== 'development') {
 }
 app.use(express.static(path.join(__dirname)));
 
+app.get('/config', (req, res) => {
+  res.send({ publishableKey: process.env.STRIPE_PUBLISHABLE_KEY });
+});
+
 app.get('/config.js', (req, res) => {
   res.type('js').send(`window.CONFIG = ${JSON.stringify({
     STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,


### PR DESCRIPTION
## Summary
- ignore `.env` secrets
- serve Stripe publishable key from new `/config` route
- initialize Stripe from `/config` in booking and checkout flows
- update CTA button id on the schedule section
- document new env variable in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ef8f7bf48323926fde2383f7acc4