### PR TITLE
Add Supabase CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy Supabase + Vercel
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm install -g supabase
+      - run: echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
+      - run: |
+          pip install -r requirements.txt
+          pytest
+      - run: |
+          supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase db push
+          supabase functions deploy register-booking
+      - uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ This dashboard is secured through Firebase Authentication and only renders for a
 
 
 
+## ⟳ CI/CD Pipeline
+
+Pushing to the `main` branch triggers GitHub Actions to run tests, deploy Supabase migrations and edge functions, and publish the frontend to Vercel. Secrets for Supabase and Vercel must be configured in the repository settings.
+
 ## 📚 Documentation
 
 - [System Architecture](docs/architecture.md)

--- a/supabase/functions/register-booking.ts
+++ b/supabase/functions/register-booking.ts
@@ -1,0 +1,21 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_ANON_KEY")!);
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const { name, email, className } = await req.json();
+  const { data, error } = await supabase
+    .from("registrations")
+    .insert({ name, email, class: className });
+
+  if (error) {
+    return new Response(error.message, { status: 500 });
+  }
+
+  return new Response(JSON.stringify(data), { status: 200 });
+});

--- a/supabase/migrations/0001_create_registrations.sql
+++ b/supabase/migrations/0001_create_registrations.sql
@@ -1,0 +1,7 @@
+create table if not exists registrations (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  email text not null,
+  class text not null,
+  created_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Supabase migrations, functions, and Vercel
- implement `register-booking` edge function
- include database migration for registrations table
- document the CI/CD process in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688afd38810c832388e527316faa6c07