### PR TITLE
Improve CI/CD workflow for Supabase & Vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,28 +1,73 @@
-name: Deploy Supabase + Vercel
+name: CI/CD
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+  pull_request:
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
-      - run: npm install -g supabase
-      - run: echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
       - run: npm ci
       - run: npm run test:agents
-      - run: |
-          pip install -r requirements.txt
-          pytest
-      - run: |
-          supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-          supabase db push
-          supabase functions deploy register-booking
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  deploy:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Populate env file
+        run: |
+          cp .env.example .env
+          sed -i 's|SUPABASE_URL=.*|SUPABASE_URL=${{ secrets.SUPABASE_URL }}|' .env
+          sed -i 's|SUPABASE_ANON_KEY=.*|SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}|' .env
+          sed -i 's|OPENAI_API_KEY=.*|OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}|' .env
+      - run: npm ci
+      - run: pip install -r requirements.txt
+      - run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+      - run: supabase db push
+      - run: supabase functions deploy register-booking
       - uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
+          alias-domains: hybriddancers.com,www.hybriddancers.com
+
+  notify:
+    if: github.event_name == 'pull_request'
+    needs: [test, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **CI Results**
+            - Tests: ${{ needs.test.result }}
+            - Deploy: ${{ needs.deploy.result }}

--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ Include the generated `config.js` before your other scripts:
 
 ## 🌐 Custom Domain with Vercel
 
-To serve the site on `www.hybriddancers.com`, configure your DNS records to point to Vercel:
+Both `hybriddancers.com` and `www.hybriddancers.com` are configured in Vercel. The root domain is marked as **primary** so traffic from `www` or the default `*.vercel.app` URL redirects to the canonical HTTPS site.
 
-| Type | Host | Value |
-|------|------|-------|
-| `A`  | `@`  | `76.76.21.21` |
-| `A`  | `www`| `76.76.21.21` |
+Configure DNS with the following records:
 
-Remove any existing records that point elsewhere. After updating, allow DNS to propagate and let Vercel provision the SSL certificate. Once verification is complete, `https://www.hybriddancers.com` will load securely.
+| Type   | Host | Value             |
+|--------|------|------------------|
+| `A`    | `@`  | `76.76.21.21`    |
+| `CNAME`| `www`| `cname.vercel-dns.com.` |
+
+After the records propagate Vercel automatically provisions SSL certificates. Custom fallback pages `error.html` (for 404s) and `offline.html` are bundled with the deployment and served when appropriate.
 
 ## 🛠️ Admin Dashboard
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "routes": [
+    { "src": "/offline", "dest": "/offline.html" },
+    { "handle": "filesystem" },
+    { "src": "/.*", "status": 404, "dest": "/error.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add CI test job and conditional deploy on main
- inject secrets into `.env` for Supabase and OpenAI
- add comment job on pull requests with deployment results
- document domain setup and fallback pages in README
- configure Vercel routes for offline and 404 pages

## Testing
- `npm run test:agents`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b053aa328832385f9e93e00e98fed