### PR TITLE
Add Instagram Reel carousel

### DIFF
--- a/api/fetchInstagramEmbed.js
+++ b/api/fetchInstagramEmbed.js
@@ -1,0 +1,19 @@
+module.exports = async function fetchInstagramEmbed(req, res) {
+  const { url } = req.query;
+  if (!url) {
+    return res.status(400).json({ error: 'url required' });
+  }
+  try {
+    const token = process.env.IG_OEMBED_TOKEN || '';
+    const endpoint = `https://graph.facebook.com/v18.0/instagram_oembed?omitscript=true&url=${encodeURIComponent(url)}${token ? `&access_token=${token}` : ''}`;
+    const response = await fetch(endpoint);
+    if (!response.ok) {
+      throw new Error(`Instagram responded ${response.status}`);
+    }
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'failed to fetch' });
+  }
+};

--- a/components/SocialReelCarousel.js
+++ b/components/SocialReelCarousel.js
@@ -1,0 +1,74 @@
+export async function SocialReelCarousel(container, reels = []) {
+  if (!container) return;
+
+  // Load Splide assets if not already present
+  const loadSplide = () => {
+    return new Promise((resolve) => {
+      if (window.Splide) return resolve();
+      const css = document.createElement('link');
+      css.rel = 'stylesheet';
+      css.href = 'https://cdn.jsdelivr.net/npm/@splidejs/splide@4/dist/css/splide.min.css';
+      document.head.appendChild(css);
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/@splidejs/splide@4/dist/js/splide.min.js';
+      script.onload = resolve;
+      document.body.appendChild(script);
+    });
+  };
+
+  await loadSplide();
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'splide';
+  const track = document.createElement('div');
+  track.className = 'splide__track';
+  const list = document.createElement('ul');
+  list.className = 'splide__list';
+  track.appendChild(list);
+  wrapper.appendChild(track);
+  container.appendChild(wrapper);
+
+  reels.forEach((url) => {
+    const li = document.createElement('li');
+    li.className = 'splide__slide';
+    li.dataset.url = url;
+    li.innerHTML = `<div class="reel-thumb" role="img" aria-label="Instagram reel placeholder"></div>`;
+    list.appendChild(li);
+  });
+
+  const splide = new Splide(wrapper, {
+    type: 'loop',
+    perPage: 1,
+    gap: '1rem',
+    pagination: true,
+    arrows: true,
+  });
+  splide.mount();
+
+  const obs = new IntersectionObserver((entries, o) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const slide = entry.target;
+        if (!slide.dataset.loaded) {
+          const api = `/api/fetchInstagramEmbed?url=${encodeURIComponent(slide.dataset.url)}`;
+          fetch(api)
+            .then((r) => r.json())
+            .then((d) => {
+              if (d && d.html) {
+                slide.innerHTML = d.html;
+              } else {
+                slide.innerHTML = `<iframe src="${slide.dataset.url}/embed" allowfullscreen loading="lazy"></iframe>`;
+              }
+            })
+            .catch(() => {
+              slide.innerHTML = '<p class="reels-error">Unable to load reel.</p>';
+            });
+          slide.dataset.loaded = '1';
+        }
+        o.unobserve(slide);
+      }
+    });
+  }, { root: wrapper, rootMargin: '0px 0px 200px 0px' });
+
+  list.querySelectorAll('.splide__slide').forEach((slide) => obs.observe(slide));
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <meta name="keywords" content="shuffle dance classes Tempe, private shuffle dance lessons AZ, learn to shuffle Arizona, beginner dance class Tempe, Tempe dance events">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@splidejs/splide@4/dist/css/splide.min.css">
+    <script src="https://unpkg.com/scrollreveal"></script>
 </head>
 <body>
     <!-- Header -->
@@ -49,15 +51,12 @@
         </div>
     </section>
 
-    <section class="instagram-reels" id="gallery">
+    <section class="latest-reels" id="latest-reels" aria-labelledby="reels-heading">
         <div class="container">
-            <h2 class="section-title">Latest Moves</h2>
-            <div class="gallery-grid">
-                <div class="gallery-item">
-                    <iframe class="lazy-embed" data-embed-src="https://www.instagram.com/hybriddancers/embed" title="Instagram video by Hybrid Dancers" allowfullscreen></iframe>
-                </div>
-            </div>
-            <a href="https://www.instagram.com/hybriddancers/" class="follow-btn" target="_blank" rel="noopener">Follow @hybriddancers</a>
+            <h2 id="reels-heading" class="section-title">Latest Moves</h2>
+            <div id="reel-carousel" aria-live="polite"></div>
+            <p id="reel-fallback" class="reels-error" style="display:none;">Unable to load reels.</p>
+            <a href="https://www.instagram.com/hybriddancers/" class="follow-btn" target="_blank" rel="noopener">Watch on Instagram</a>
         </div>
     </section>
 
@@ -260,6 +259,7 @@
     </footer>
 
     <script async src="https://assets.calendly.com/assets/external/widget.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4/dist/js/splide.min.js"></script>
     <script src="/config.js"></script>
     <script src="checkout.js"></script>
     <script type="module" src="scripts.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -1,3 +1,4 @@
+import { SocialReelCarousel } from './components/SocialReelCarousel.js';
 console.log('✅ App initialized.');
 
 // ScrollReveal animations for Hybrid Dancers site
@@ -30,13 +31,26 @@ window.showToast = showToast;
 document.addEventListener('DOMContentLoaded', () => {
     createToastContainer();
 
+    const carouselEl = document.getElementById('reel-carousel');
+    if (carouselEl) {
+        const reelUrls = [
+            'https://www.instagram.com/p/CyGZc8UPL2g',
+            'https://www.instagram.com/p/CyDyapCrkYZ',
+            'https://www.instagram.com/p/Cx7OPawrQxt'
+        ];
+        SocialReelCarousel(carouselEl, reelUrls).catch(() => {
+            const fb = document.getElementById('reel-fallback');
+            if (fb) fb.style.display = 'block';
+        });
+    }
+
     if (typeof ScrollReveal !== 'undefined') {
         const sr = ScrollReveal({ distance: '40px', duration: 800, easing: 'ease-out', cleanup: true });
         sr.reveal('.hero-content', { opacity: 0, duration: 1000 });
         sr.reveal('.class-card', { origin: 'bottom', interval: 100 });
         sr.reveal('.pricing-card', { origin: 'bottom', interval: 100 });
         sr.reveal('.instagram-feed', { delay: 300, origin: 'bottom' });
-        sr.reveal('.instagram-reels', { delay: 300, origin: 'bottom' });
+        sr.reveal('.latest-reels', { delay: 300, origin: 'bottom' });
     }
 
     // Smooth scrolling for navigation links

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const path = require('path');
 const fs = require('fs');
 const { nanoid } = require('nanoid');
+const fetchInstagramEmbed = require('./api/fetchInstagramEmbed');
 
 const PORT = process.env.PORT || 4242;
 const DOMAIN_URL = process.env.DOMAIN_URL || `http://localhost:${PORT}`;
@@ -105,6 +106,9 @@ app.delete('/api/bookings/:id', (req, res) => {
   logAction('delete_booking', req.params.id);
   res.json({ id: req.params.id });
 });
+
+// Instagram oEmbed proxy
+app.get('/api/fetchInstagramEmbed', fetchInstagramEmbed);
 
 // --- Logs API ---
 // Return the raw log entries used by automation agents and admin tools

--- a/style.css
+++ b/style.css
@@ -761,24 +761,45 @@
             line-height: 1.6;
         }
 
-        .instagram-reels {
-            background: linear-gradient(135deg, #8C1D40, #FFB300);
-            color: #F5F5DC;
-            padding: 3rem 1rem;
-            text-align: center;
-        }
 
-        .reels-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            gap: 1rem;
+.latest-reels {
+    background: linear-gradient(135deg, #8C1D40, #FFB300);
+    color: #F5F5DC;
+    padding: 3rem 1rem;
+    text-align: center;
+}
+
+
+        #latest-reels .splide {
             margin-top: 2rem;
         }
 
-        .reel-video {
+        #latest-reels .splide__slide {
+            position: relative;
+        }
+
+        .reel-thumb {
             width: 100%;
+            padding-top: 177%;
+            background: #000;
             border-radius: 15px;
-            overflow: hidden;
+        }
+
+        #latest-reels iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+            border-radius: 15px;
+        }
+
+        @media (max-width: 768px) {
+            #latest-reels .splide__slide {
+                width: 80%;
+                margin: 0 auto;
+            }
         }
 
         .follow-btn {

--- a/supabase/functions/fetch-oembed.ts
+++ b/supabase/functions/fetch-oembed.ts
@@ -1,0 +1,18 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+
+serve(async (req) => {
+  const { searchParams } = new URL(req.url);
+  const url = searchParams.get('url');
+  if (!url) {
+    return new Response('url required', { status: 400 });
+  }
+  const token = Deno.env.get('IG_OEMBED_TOKEN') ?? '';
+  const endpoint = `https://graph.facebook.com/v18.0/instagram_oembed?omitscript=true&url=${encodeURIComponent(url)}${token ? `&access_token=${token}` : ''}`;
+  try {
+    const res = await fetch(endpoint);
+    const text = await res.text();
+    return new Response(text, { headers: { 'Content-Type': 'application/json' } });
+  } catch (_) {
+    return new Response('error', { status: 500 });
+  }
+});


### PR DESCRIPTION
## Summary
- integrate Splide-based `SocialReelCarousel` component
- serve Instagram oEmbed via new proxy endpoint
- style and animate new `Latest Moves` section
- lazy load reels in `scripts.js`
- provide optional Supabase Edge Function for oEmbed proxy

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0c7a09608323a7198a1b6a40b797