### PR TITLE
Add Instagram Reels carousel with lazy loading

### DIFF
--- a/api/fetchInstagramEmbed.js
+++ b/api/fetchInstagramEmbed.js
@@ -1,8 +1,17 @@
+const cache = new Map();
+const TTL = 60 * 60 * 1000; // one hour
+
 module.exports = async function fetchInstagramEmbed(req, res) {
   const { url } = req.query;
   if (!url) {
     return res.status(400).json({ error: 'url required' });
   }
+
+  const cached = cache.get(url);
+  if (cached && Date.now() - cached.time < TTL) {
+    return res.json(cached.data);
+  }
+
   try {
     const token = process.env.IG_OEMBED_TOKEN || '';
     const endpoint = `https://graph.facebook.com/v18.0/instagram_oembed?omitscript=true&url=${encodeURIComponent(url)}${token ? `&access_token=${token}` : ''}`;
@@ -11,9 +20,10 @@ module.exports = async function fetchInstagramEmbed(req, res) {
       throw new Error(`Instagram responded ${response.status}`);
     }
     const data = await response.json();
+    cache.set(url, { time: Date.now(), data });
     res.json(data);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'failed to fetch' });
+    res.json({ html: `<iframe src="${url}/embed" allowfullscreen loading="lazy"></iframe>` });
   }
 };

--- a/index.html
+++ b/index.html
@@ -56,6 +56,10 @@
             <h2 id="reels-heading" class="section-title">Latest Moves</h2>
             <div id="reel-carousel" aria-live="polite"></div>
             <p id="reel-fallback" class="reels-error" style="display:none;">Unable to load reels.</p>
+            <noscript>
+                <p class="reels-error">Enable JavaScript to view our Instagram Reels.</p>
+                <iframe src="https://www.instagram.com/hybriddancers/embed" loading="lazy" title="Hybrid Dancers Instagram" class="lazy-embed"></iframe>
+            </noscript>
             <a href="https://www.instagram.com/hybriddancers/" class="follow-btn" target="_blank" rel="noopener">Watch on Instagram</a>
         </div>
     </section>

--- a/scripts.js
+++ b/scripts.js
@@ -38,10 +38,24 @@ document.addEventListener('DOMContentLoaded', () => {
             'https://www.instagram.com/p/CyDyapCrkYZ',
             'https://www.instagram.com/p/Cx7OPawrQxt'
         ];
-        SocialReelCarousel(carouselEl, reelUrls).catch(() => {
-            const fb = document.getElementById('reel-fallback');
-            if (fb) fb.style.display = 'block';
-        });
+        const startCarousel = () => {
+            SocialReelCarousel(carouselEl, reelUrls).catch(() => {
+                const fb = document.getElementById('reel-fallback');
+                if (fb) fb.style.display = 'block';
+            });
+        };
+        const section = document.getElementById('latest-reels');
+        if ('IntersectionObserver' in window && section) {
+            const ob = new IntersectionObserver((entries, o) => {
+                if (entries[0].isIntersecting) {
+                    startCarousel();
+                    o.disconnect();
+                }
+            }, { rootMargin: '0px 0px 200px 0px' });
+            ob.observe(section);
+        } else {
+            startCarousel();
+        }
     }
 
     if (typeof ScrollReveal !== 'undefined') {

--- a/style.css
+++ b/style.css
@@ -780,7 +780,7 @@
 
         .reel-thumb {
             width: 100%;
-            padding-top: 177%;
+            padding-top: 100%;
             background: #000;
             border-radius: 15px;
         }
@@ -798,6 +798,13 @@
         @media (max-width: 768px) {
             #latest-reels .splide__slide {
                 width: 80%;
+                margin: 0 auto;
+            }
+        }
+
+        @media (min-width: 1024px) {
+            #latest-reels .splide__slide {
+                max-width: 480px;
                 margin: 0 auto;
             }
         }

--- a/supabase/functions/fetch-oembed.ts
+++ b/supabase/functions/fetch-oembed.ts
@@ -1,18 +1,29 @@
 import { serve } from "https://deno.land/std/http/server.ts";
 
+const cache = new Map<string, { time: number; data: string }>();
+const TTL = 60 * 60 * 1000; // 1 hour
+
 serve(async (req) => {
   const { searchParams } = new URL(req.url);
   const url = searchParams.get('url');
   if (!url) {
     return new Response('url required', { status: 400 });
   }
+
+  const cached = cache.get(url);
+  if (cached && Date.now() - cached.time < TTL) {
+    return new Response(cached.data, { headers: { "Content-Type": "application/json" } });
+  }
+
   const token = Deno.env.get('IG_OEMBED_TOKEN') ?? '';
   const endpoint = `https://graph.facebook.com/v18.0/instagram_oembed?omitscript=true&url=${encodeURIComponent(url)}${token ? `&access_token=${token}` : ''}`;
   try {
     const res = await fetch(endpoint);
     const text = await res.text();
+    cache.set(url, { time: Date.now(), data: text });
     return new Response(text, { headers: { 'Content-Type': 'application/json' } });
   } catch (_) {
-    return new Response('error', { status: 500 });
+    const fallback = JSON.stringify({ html: `<iframe src="${url}/embed" allowfullscreen loading="lazy"></iframe>` });
+    return new Response(fallback, { headers: { 'Content-Type': 'application/json' } });
   }
 });


### PR DESCRIPTION
## Summary
- improve oEmbed proxy with caching and fallback
- cache Instagram oEmbed responses in Supabase edge function
- add `<noscript>` fallback in Latest Moves section
- lazy-load carousel with IntersectionObserver
- adjust reel aspect ratio and responsive breakpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm run test:agents`


------
https://chatgpt.com/codex/tasks/task_e_688b0e49fbec8323a83732429ec4787d