### PR TITLE
Add SocialMediaShowcase with dynamic social embeds

### DIFF
--- a/components/SocialMediaShowcase.js
+++ b/components/SocialMediaShowcase.js
@@ -1,0 +1,57 @@
+export function SocialMediaShowcase(section) {
+  if (!section) return;
+
+  const preview = new URLSearchParams(window.location.search).get('previewSocial');
+  if (preview !== 'true') {
+    section.style.display = 'none';
+    return;
+  }
+
+  const start = () => {
+    const { SOCIAL_LINKS } = window;
+    if (!SOCIAL_LINKS) return;
+
+    const carouselEl = section.querySelector('.instagram-carousel');
+    if (carouselEl) {
+      const reels = [
+        `${SOCIAL_LINKS.instagram}p/CyGZc8UPL2g`,
+        `${SOCIAL_LINKS.instagram}p/CyDyapCrkYZ`,
+        `${SOCIAL_LINKS.instagram}p/Cx7OPawrQxt`
+      ];
+      if (window.SocialReelCarousel) {
+        window.SocialReelCarousel(carouselEl, reels);
+      }
+    }
+
+    const loadTikTok = () => {
+      if (!section.querySelector('.tiktok-embed')) {
+        return;
+      }
+      if (!document.querySelector('script[src="https://www.tiktok.com/embed.js"]')) {
+        const script = document.createElement('script');
+        script.src = 'https://www.tiktok.com/embed.js';
+        document.body.appendChild(script);
+      }
+    };
+
+    const tiktok = section.querySelector('.tiktok-embed');
+    if (tiktok) loadTikTok();
+
+    const fb = section.querySelector('.fb-post');
+    if (fb && !fb.src) {
+      fb.src = `${SOCIAL_LINKS.facebook}embed`;
+    }
+  };
+
+  if ('IntersectionObserver' in window) {
+    const obs = new IntersectionObserver((entries, o) => {
+      if (entries[0].isIntersecting) {
+        start();
+        o.disconnect();
+      }
+    }, { rootMargin: '0px 0px 200px 0px' });
+    obs.observe(section);
+  } else {
+    start();
+  }
+}

--- a/index.html
+++ b/index.html
@@ -64,16 +64,22 @@
         </div>
     </section>
 
-    <section class="social-feed" id="social">
+    <section id="social-showcase" class="social-showcase" aria-label="Social Media Showcase">
         <div class="container">
-            <h2 class="section-title">Social Highlights</h2>
+            <h2 class="section-title">Social Media Showcase</h2>
             <div class="social-grid">
-                <div class="social-item">
+                <figure class="social-item">
+                    <div class="instagram-carousel" aria-label="Instagram reels"></div>
+                    <figcaption>Instagram Reels</figcaption>
+                </figure>
+                <figure class="social-item">
                     <blockquote class="tiktok-embed" cite="https://www.tiktok.com/@hybrid.dancers" data-unique-id="hybrid.dancers" data-embed-type="creator" aria-label="TikTok embed from Hybrid Dancers"></blockquote>
-                </div>
-                <div class="social-item">
-                    <div class="fb-page" data-href="https://www.facebook.com/people/Hybrid-Dancers/61577357196451/" data-tabs="timeline" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true" aria-label="Facebook embed from Hybrid Dancers"></div>
-                </div>
+                    <figcaption>TikTok</figcaption>
+                </figure>
+                <figure class="social-item">
+                    <iframe class="fb-post" title="Facebook post" loading="lazy"></iframe>
+                    <figcaption>Facebook</figcaption>
+                </figure>
             </div>
         </div>
     </section>

--- a/scripts.js
+++ b/scripts.js
@@ -1,7 +1,10 @@
 import { SocialReelCarousel } from './components/SocialReelCarousel.js';
+import { SocialMediaShowcase } from './components/SocialMediaShowcase.js';
 import { SOCIAL_LINKS } from './socialLinks.js';
 console.log('✅ App initialized.');
 window.SOCIAL_LINKS = SOCIAL_LINKS;
+window.SocialReelCarousel = SocialReelCarousel;
+window.SocialMediaShowcase = SocialMediaShowcase;
 
 // ScrollReveal animations for Hybrid Dancers site
 // Applies fade-in on hero content, slide-up on cards, and delayed Instagram reveal
@@ -58,6 +61,11 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             startCarousel();
         }
+    }
+
+    const showcase = document.getElementById('social-showcase');
+    if (showcase) {
+        SocialMediaShowcase(showcase);
     }
 
     if (typeof ScrollReveal !== 'undefined') {

--- a/server.js
+++ b/server.js
@@ -110,6 +110,27 @@ app.delete('/api/bookings/:id', (req, res) => {
 // Instagram oEmbed proxy
 app.get('/api/fetchInstagramEmbed', fetchInstagramEmbed);
 
+// Aggregate social feed
+app.get('/api/social-feed', async (req, res) => {
+  const reels = [
+    'https://www.instagram.com/p/CyGZc8UPL2g',
+    'https://www.instagram.com/p/CyDyapCrkYZ',
+    'https://www.instagram.com/p/Cx7OPawrQxt'
+  ];
+  try {
+    const ig = await Promise.all(
+      reels.map(url =>
+        fetch(`${req.protocol}://${req.get('host')}/api/fetchInstagramEmbed?url=${encodeURIComponent(url)}`)
+          .then(r => r.json())
+          .catch(() => ({ html: `<iframe src="${url}/embed" allowfullscreen loading="lazy"></iframe>` }))
+      )
+    );
+    res.json({ instagram: ig });
+  } catch (err) {
+    res.json({ instagram: reels.map(url => ({ html: `<iframe src="${url}/embed" allowfullscreen loading="lazy"></iframe>` })) });
+  }
+});
+
 // --- Logs API ---
 // Return the raw log entries used by automation agents and admin tools
 app.get('/api/logs', (req, res) => {

--- a/style.css
+++ b/style.css
@@ -770,11 +770,13 @@
 }
 
 
-        #latest-reels .splide {
+        #latest-reels .splide,
+        #social-showcase .splide {
             margin-top: 2rem;
         }
 
-        #latest-reels .splide__slide {
+        #latest-reels .splide__slide,
+        #social-showcase .splide__slide {
             position: relative;
         }
 
@@ -785,7 +787,8 @@
             border-radius: 15px;
         }
 
-        #latest-reels iframe {
+        #latest-reels iframe,
+        #social-showcase iframe {
             position: absolute;
             top: 0;
             left: 0;
@@ -796,14 +799,16 @@
         }
 
         @media (max-width: 768px) {
-            #latest-reels .splide__slide {
+            #latest-reels .splide__slide,
+            #social-showcase .splide__slide {
                 width: 80%;
                 margin: 0 auto;
             }
         }
 
         @media (min-width: 1024px) {
-            #latest-reels .splide__slide {
+            #latest-reels .splide__slide,
+            #social-showcase .splide__slide {
                 max-width: 480px;
                 margin: 0 auto;
             }
@@ -1553,7 +1558,8 @@
 }
 
 /* Social embed sections */
-.social-feed {
+.social-feed,
+.social-showcase {
     background: #f9f9f9;
     padding: 3rem 1rem;
     text-align: center;


### PR DESCRIPTION
## Summary
- implement new `SocialMediaShowcase` component
- hook showcase loading into `scripts.js`
- add `<section id="social-showcase">` to home page
- style showcase section alongside latest reels
- expose `/api/social-feed` endpoint

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b1251e1dc83239351a3d5a662a689