### PR TITLE
Improve fallback for broken social embeds

### DIFF
--- a/components/SocialMediaShowcase.js
+++ b/components/SocialMediaShowcase.js
@@ -13,19 +13,33 @@ export function SocialMediaShowcase(section) {
     return sk;
   };
 
+  const showFallback = (el, url) => {
+    const link = url ? `<a href="${url}" target="_blank" rel="noopener">Open post</a>` : '';
+    el.innerHTML = `<p class="embed-error">Follow us on Instagram to view our latest moves. ${link}</p>`;
+  };
+
   const loadEmbed = (el, url) => {
     if (!url) return;
     const sk = addSkeleton(el);
-    injectEmbed(el, url).finally(() => {
-      const obs = new MutationObserver((m, o) => {
-        if (el.querySelector('iframe') || el.querySelector('blockquote')) {
-          sk.remove();
-          el.classList.add('loaded');
-          o.disconnect();
+    injectEmbed(el, url)
+      .then(() => {
+        // if injected html is empty or lacks iframe/blockquote, show fallback
+        const hasContent = el.querySelector('iframe') || el.querySelector('blockquote');
+        if (!hasContent) {
+          showFallback(el, url);
         }
+      })
+      .catch(() => showFallback(el, url))
+      .finally(() => {
+        const obs = new MutationObserver((m, o) => {
+          if (el.querySelector('iframe') || el.querySelector('blockquote')) {
+            sk.remove();
+            el.classList.add('loaded');
+            o.disconnect();
+          }
+        });
+        obs.observe(el, { childList: true, subtree: true });
       });
-      obs.observe(el, { childList: true, subtree: true });
-    });
   };
 
   const start = () => {


### PR DESCRIPTION
## Summary
- detect when embeds fail to load and show a fallback message
- confirm that IG_OEMBED_TOKEN is documented in the README

## Testing
- `pytest -q`
- `curl -s "http://localhost:4242/api/fetchOEmbed?url=https://www.instagram.com/p/CyGZc8UPL2g" | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688b1fc2c4788323a288f571bb2388ed