### PR TITLE
docs: add technical roadmap

### DIFF
--- a/docs/ROADMAP_CHECKLIST.md
+++ b/docs/ROADMAP_CHECKLIST.md
@@ -1,11 +1,9 @@
 # Roadmap Checklist
 
-The following tasks summarize the short-term goals outlined in `TECHNICAL_ROADMAP.md`.
+The following tasks summarize the near-term goals outlined in [TECHNICAL_ROADMAP.md](TECHNICAL_ROADMAP.md).
 
-- [ ] Clean up API keys and rely solely on environment variables
+- [ ] Remove hard-coded API keys and use environment variables
+- [ ] Expand automated tests for booking and auth flows
+- [ ] Publish privacy policy and terms of service in production
+- [ ] Improve mobile user experience and responsive layout
 - [x] Enforce HTTPS for all routes and assets
-- [ ] Publish a privacy policy and terms of service
-- [ ] Extend automated tests for booking and auth flows
-- [ ] Improve mobile user experience and layout
-
-

--- a/docs/TECHNICAL_ROADMAP.md
+++ b/docs/TECHNICAL_ROADMAP.md
@@ -1,0 +1,11 @@
+# Technical Roadmap
+
+This document outlines the near-term engineering priorities for the Hybrid Dancers platform.
+
+## Q3 2024 Priorities
+
+- **Remove hard-coded API keys:** Rely solely on environment variables for configuration and secrets.
+- **Publish legal policies:** Expose the privacy policy and terms of service within the production site.
+- **Expand automated tests:** Cover booking and authentication flows to prevent regressions.
+- **Improve mobile experience:** Refine responsive layouts for booking, dashboard and signup pages.
+- **Enforce HTTPS everywhere:** Maintain secure delivery of all routes and assets.


### PR DESCRIPTION
## Summary
- document near-term engineering priorities in a new Technical Roadmap
- align Roadmap Checklist with the new roadmap and current priorities

## Testing
- `npm run test:agents`

------
https://chatgpt.com/codex/tasks/task_e_68910ccc012c8323811f0aef519de369