### PR TITLE
refactor file IO to async

### DIFF
--- a/agents/attendance-agent.js
+++ b/agents/attendance-agent.js
@@ -1,27 +1,27 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const { logToSupabase } = require('./supabase-log');
 
 const bookingsFile = path.join(__dirname, '..', 'data', 'bookings.json');
 const logFile = path.join(__dirname, '..', 'data', 'logs.json');
 
-function readJson(file) {
+async function readJson(file) {
   try {
-    return JSON.parse(fs.readFileSync(file));
+    return JSON.parse(await fs.readFile(file, 'utf8'));
   } catch (e) {
     return [];
   }
 }
 
-function writeJson(file, data) {
-  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+async function writeJson(file, data) {
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
 }
 
-function logAction(action, details) {
-  const logs = readJson(logFile);
+async function logAction(action, details) {
+  const logs = await readJson(logFile);
   logs.push({ time: new Date().toISOString(), action, details });
-  writeJson(logFile, logs);
-  logToSupabase(action, details);
+  await writeJson(logFile, logs);
+  await logToSupabase(action, details);
 }
 
 function detectAnomalies(bookings) {
@@ -37,11 +37,11 @@ function detectAnomalies(bookings) {
     .map(([d]) => d);
 }
 
-function run() {
-  const bookings = readJson(bookingsFile);
+async function run() {
+  const bookings = await readJson(bookingsFile);
   const anomalies = detectAnomalies(bookings);
   if (anomalies.length) {
-    logAction('attendance_anomaly', anomalies.join(','));
+    await logAction('attendance_anomaly', anomalies.join(','));
     console.log('Anomalies detected:', anomalies.join(','));
   } else {
     console.log('No anomalies detected');

--- a/agents/insights-agent.js
+++ b/agents/insights-agent.js
@@ -1,27 +1,27 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const { logToSupabase } = require('./supabase-log');
 
 const bookingsFile = path.join(__dirname, '..', 'data', 'bookings.json');
 const logFile = path.join(__dirname, '..', 'data', 'logs.json');
 
-function readJson(file) {
+async function readJson(file) {
   try {
-    return JSON.parse(fs.readFileSync(file));
+    return JSON.parse(await fs.readFile(file, 'utf8'));
   } catch (e) {
     return [];
   }
 }
 
-function writeJson(file, data) {
-  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+async function writeJson(file, data) {
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
 }
 
-function logAction(action, details) {
-  const logs = readJson(logFile);
+async function logAction(action, details) {
+  const logs = await readJson(logFile);
   logs.push({ time: new Date().toISOString(), action, details });
-  writeJson(logFile, logs);
-  logToSupabase(action, details);
+  await writeJson(logFile, logs);
+  await logToSupabase(action, details);
 }
 
 function getTopDay(bookings) {
@@ -55,8 +55,8 @@ function getMonthlyTrend(bookings) {
   return `last_month=${last};prev_month=${prev};diff=${diff}`;
 }
 
-function run() {
-  const bookings = readJson(bookingsFile);
+async function run() {
+  const bookings = await readJson(bookingsFile);
   if (!bookings.length) {
     console.log('No bookings to analyze');
     return;
@@ -65,7 +65,7 @@ function run() {
   const topClass = getTopClass(bookings);
   const trend = getMonthlyTrend(bookings);
   const details = `top_day=${topDay};top_class=${topClass}${trend ? ';' + trend : ''}`;
-  logAction('insights_generated', details);
+  await logAction('insights_generated', details);
   console.log('Insights:', details);
 }
 

--- a/agents/trends-agent.js
+++ b/agents/trends-agent.js
@@ -1,27 +1,27 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const { logToSupabase } = require('./supabase-log');
 
 const bookingsFile = path.join(__dirname, '..', 'data', 'bookings.json');
 const logFile = path.join(__dirname, '..', 'data', 'logs.json');
 
-function readJson(file) {
+async function readJson(file) {
   try {
-    return JSON.parse(fs.readFileSync(file));
+    return JSON.parse(await fs.readFile(file, 'utf8'));
   } catch (e) {
     return [];
   }
 }
 
-function writeJson(file, data) {
-  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+async function writeJson(file, data) {
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
 }
 
-function logAction(action, details) {
-  const logs = readJson(logFile);
+async function logAction(action, details) {
+  const logs = await readJson(logFile);
   logs.push({ time: new Date().toISOString(), action, details });
-  writeJson(logFile, logs);
-  logToSupabase(action, details);
+  await writeJson(logFile, logs);
+  await logToSupabase(action, details);
 }
 
 function filterBookings(bookings, days) {
@@ -99,11 +99,11 @@ function detectTrends(bookings, periods = [30, 60, 90]) {
   return results;
 }
 
-function run() {
-  const bookings = readJson(bookingsFile);
+async function run() {
+  const bookings = await readJson(bookingsFile);
   const summaries = detectTrends(bookings);
   if (summaries.length) {
-    logAction('trends_analysis', summaries.join(';'));
+    await logAction('trends_analysis', summaries.join(';'));
     console.log('Trends:', summaries.join('\n'));
   } else {
     console.log('No significant trends found');

--- a/api/fetchOEmbed.js
+++ b/api/fetchOEmbed.js
@@ -1,16 +1,16 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 
 const cache = new Map();
 const TTL = 60 * 60 * 1000; // one hour
 
-function logError(msg) {
+async function logError(msg) {
   console.error(msg);
   try {
     const file = path.join(__dirname, '..', 'data', 'logs.json');
-    const logs = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const logs = JSON.parse(await fs.readFile(file, 'utf8'));
     logs.push({ time: new Date().toISOString(), action: 'oembed_error', details: msg });
-    fs.writeFileSync(file, JSON.stringify(logs, null, 2));
+    await fs.writeFile(file, JSON.stringify(logs, null, 2));
   } catch (e) {
     console.error('Failed to write log', e);
   }
@@ -60,7 +60,7 @@ module.exports = async function fetchOEmbed(req, res) {
     cache.set(normalized, { time: Date.now(), data });
     res.json(data);
   } catch (err) {
-    logError(err.message);
+    await logError(err.message);
     res.json({ html: `<iframe src="${normalized}/embed" allowfullscreen loading="lazy"></iframe>` });
   }
 };


### PR DESCRIPTION
## Summary
- switch server and agents to async `fs.promises` helpers
- await JSON file operations and logging across routes and agents
- log oEmbed errors asynchronously

## Testing
- `npm run test:agents`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689110643bb08323b2df72d3e6c9ac33