### PR TITLE
Ignore debug logs and document local logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .pytest_cache/
 node_modules/
 .env
+*-debug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,19 @@ Thank you for helping improve the Hybrid Dancers website! This project mixes a s
 - Keep functions small and well commented.
 - Use environment variables for secrets; never hard‑code API keys.
 - Ensure `pytest` passes before submitting.
+ 
+## Local Debug Logs
+
+During development you may want to capture verbose logs. Redirect output to a file ending in `-debug.log`, which is ignored by Git:
+
+```bash
+node server.js > server-debug.log 2>&1
+```
+
+Agent scripts write to `data/logs.json` for traceability. If you generate logs locally, restore that file before committing so log data isn't checked in:
+
+```bash
+git restore data/logs.json
+```
 
 We appreciate all issues and pull requests. Happy coding!


### PR DESCRIPTION
## Summary
- ignore `*-debug.log` files and remove the existing `pglite-debug.log`
- guide contributors on using local debug logs without committing them

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891146dc558832391f04a49e8e426d5